### PR TITLE
OpenFeature: Support string type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.0" // your current series x.y
+ThisBuild / tlBaseVersion := "0.1" // your current series x.y
 
 ThisBuild / organization     := "io.cardell"
 ThisBuild / organizationName := "Alex Cardell"

--- a/docker/flipt/features.yaml
+++ b/docker/flipt/features.yaml
@@ -19,6 +19,17 @@ flags:
     distributions:
     - variant: key-1
       rollout: 100
+- key: string-variant-flag-1
+  name: string-variant-flag-1
+  type: VARIANT_FLAG_TYPE
+  enabled: true
+  variants:
+  - key: string-variant-1
+  rules:
+  - segment: default-ns-segment-1
+    distributions:
+    - variant: string-variant-1
+      rollout: 100
 segments:
 - key: default-ns-segment-1
   name: default-ns-segment-1

--- a/open-feature/provider-flipt-it/src/test/scala/io/cardell/openfeature/provider/flipt/FliptProviderItTest.scala
+++ b/open-feature/provider-flipt-it/src/test/scala/io/cardell/openfeature/provider/flipt/FliptProviderItTest.scala
@@ -31,6 +31,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import io.cardell.ff4s.flipt.FliptApi
 import io.cardell.ff4s.flipt.auth.AuthenticationStrategy
 import io.cardell.openfeature.EvaluationContext
+import io.cardell.openfeature.ContextValue
 
 class FliptProviderItTest extends CatsEffectSuite with TestContainerForAll {
 
@@ -83,39 +84,38 @@ class FliptProviderItTest extends CatsEffectSuite with TestContainerForAll {
     }
   }
 
-  // test("uses default when boolean flag missing") {
-  //   withContainers { containers =>
-  //     api(containers).use { flipt =>
-  //       for {
-  //         res <- flipt.resolveBooleanValue(
-  //           "no-flag",
-  //           false,
-  //           EvaluationContext.empty
-  //         )
-  //       } yield assertEquals(res.value, false)
-  //     }
-  //   }
-  // }
+  test("uses default when boolean flag missing") {
+    withContainers { containers =>
+      api(containers).use { flipt =>
+        for {
+          res <- flipt.resolveBooleanValue(
+            "no-flag",
+            false,
+            EvaluationContext.empty
+          )
+        } yield assertEquals(res.value, false)
+      }
+    }
+  }
 
-  // test("receives variant match when in segment rule") {
-  //   withContainers { containers =>
-  //     api(containers).use { flipt =>
-  //       val segmentContext = Map("test-property" -> "matched-property-value")
-  //       for {
-  //         res <- flipt.evaluateVariant(
-  //           EvaluationRequest(
-  //             "default",
-  //             "variant-flag-1",
-  //             None,
-  //             segmentContext,
-  //             None
-  //           )
-  //         )
-  //       } yield assertEquals(res.`match`, true)
-  //     }
-  //   }
-  // }
-  //
+  test("receives variant match when in segment rule") {
+    withContainers { containers =>
+      api(containers).use { flipt =>
+        val segmentContext = Map(
+          "test-property" -> ContextValue.StringValue("matched-property-value")
+        )
+
+        for {
+          res <- flipt.resolveStringValue(
+            "string-variant-flag-1",
+            "default-string",
+            EvaluationContext(None, segmentContext)
+          )
+        } yield assertEquals(res.value, "string-variant-1")
+      }
+    }
+  }
+
   // test("receives no variant match when not in segment rule") {
   //   withContainers { containers =>
   //     api(containers).use { flipt =>

--- a/open-feature/provider-flipt/src/main/scala/io/cardell/openfeature/provider/flipt/FliptProvider.scala
+++ b/open-feature/provider-flipt/src/main/scala/io/cardell/openfeature/provider/flipt/FliptProvider.scala
@@ -75,7 +75,7 @@ class FliptProvider[F[_]: MonadThrow](flipt: FliptApi[F], namespace: String)
       value = defaultValue,
       errorCode = Some(ErrorCode.General),
       errorMessage = Some(t.getMessage()),
-      reason = Some(EvaluationReason.Default),
+      reason = Some(EvaluationReason.Error),
       variant = None,
       metadata = None
     )

--- a/open-feature/sdk/src/main/scala/io/cardell/openfeature/FeatureClient.scala
+++ b/open-feature/sdk/src/main/scala/io/cardell/openfeature/FeatureClient.scala
@@ -71,34 +71,38 @@ trait FeatureClient[F[_]] {
       options: EvaluationOptions
   ): F[EvaluationDetails[Boolean]]
 
-  // def getStringValue(flagKey: String, default: String): F[String]
-  // def getStringValue(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext
-  // ): F[String]
-  // def getStringValue(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext,
-  //     options: EvaluationOptions
-  // ): F[String]
-  //
-  // def getStringDetails(
-  //     flagKey: String,
-  //     default: String
-  // ): F[EvaluationDetails[String]]
-  // def getStringDetails(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext
-  // ): F[EvaluationDetails[String]]
-  // def getStringDetails(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext,
-  //     options: EvaluationOptions
-  // ): F[EvaluationDetails[String]]
+  def getStringValue(flagKey: String, default: String): F[String]
+
+  def getStringValue(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext
+  ): F[String]
+
+  def getStringValue(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext,
+      options: EvaluationOptions
+  ): F[String]
+
+  def getStringDetails(
+      flagKey: String,
+      default: String
+  ): F[EvaluationDetails[String]]
+
+  def getStringDetails(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext
+  ): F[EvaluationDetails[String]]
+
+  def getStringDetails(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext,
+      options: EvaluationOptions
+  ): F[EvaluationDetails[String]]
   //
   // def getIntValue(flagKey: String, default: Int): F[Int]
   // def getIntValue(
@@ -186,4 +190,5 @@ trait FeatureClient[F[_]] {
   //     context: EvaluationContext,
   //     options: EvaluationOptions
   // ): F[EvaluationDetails[A]]
+
 }

--- a/open-feature/sdk/src/main/scala/io/cardell/openfeature/FeatureClientImpl.scala
+++ b/open-feature/sdk/src/main/scala/io/cardell/openfeature/FeatureClientImpl.scala
@@ -95,53 +95,62 @@ protected[openfeature] final class FeatureClientImpl[F[_]: Monad](
     )
     .map(EvaluationDetails[Boolean](flagKey, _))
 
-  // override def getStringValue(flagKey: String, default: String): F[String] =
-  //   getStringValue(flagKey, default, EvaluationContext.empty)
-  //
-  // override def getStringValue(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext
-  // ): F[String] =
-  //   getStringValue(
-  //     flagKey,
-  //     default,
-  //     context,
-  //     EvaluationOptions.Defaults
-  //   )
-  //
-  // override def getStringValue(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext,
-  //     options: EvaluationOptions
-  // ): F[String] =
-  //   getStringDetails(flagKey, default, context, EvaluationOptions.Defaults)
-  //     .map(_.value)
-  //
-  // override def getStringDetails(
-  //     flagKey: String,
-  //     default: String
-  // ): F[EvaluationDetails[String]] =
-  //   getStringDetails(flagKey, default, EvaluationContext.empty)
-  //
-  // override def getStringDetails(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext
-  // ): F[EvaluationDetails[String]] =
-  //   getStringDetails(flagKey, default, context, EvaluationOptions.Defaults)
-  //
-  // override def getStringDetails(
-  //     flagKey: String,
-  //     default: String,
-  //     context: EvaluationContext,
-  //     options: EvaluationOptions
-  // ): F[EvaluationDetails[String]] =
-  //   provider
-  //     .resolveStringValue(flagKey, default, clientEvaluationContext ++ context)
-  //     .map(EvaluationDetails[String](flagKey, _))
-  //
+  override def getStringValue(flagKey: String, default: String): F[String] =
+    getStringValue(flagKey, default, EvaluationContext.empty)
+
+  override def getStringValue(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext
+  ): F[String] = getStringValue(
+    flagKey,
+    default,
+    context,
+    EvaluationOptions.Defaults
+  )
+
+  override def getStringValue(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext,
+      options: EvaluationOptions
+  ): F[String] = getStringDetails(
+    flagKey,
+    default,
+    context,
+    EvaluationOptions.Defaults
+  )
+    .map(_.value)
+
+  override def getStringDetails(
+      flagKey: String,
+      default: String
+  ): F[EvaluationDetails[String]] = getStringDetails(
+    flagKey,
+    default,
+    EvaluationContext.empty
+  )
+
+  override def getStringDetails(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext
+  ): F[EvaluationDetails[String]] = getStringDetails(
+    flagKey,
+    default,
+    context,
+    EvaluationOptions.Defaults
+  )
+
+  override def getStringDetails(
+      flagKey: String,
+      default: String,
+      context: EvaluationContext,
+      options: EvaluationOptions
+  ): F[EvaluationDetails[String]] = provider
+    .resolveStringValue(flagKey, default, clientEvaluationContext ++ context)
+    .map(EvaluationDetails[String](flagKey, _))
+
   // override def getIntValue(flagKey: String, default: Int): F[Int] =
   //   getIntValue(flagKey, default, EvaluationContext.empty)
   //

--- a/open-feature/sdk/src/main/scala/io/cardell/openfeature/provider/Provider.scala
+++ b/open-feature/sdk/src/main/scala/io/cardell/openfeature/provider/Provider.scala
@@ -28,12 +28,12 @@ trait Provider[F[_]] {
       context: EvaluationContext
   ): F[ResolutionDetails[Boolean]]
 
-  // def resolveStringValue(
-  //     flagKey: String,
-  //     defaultValue: String,
-  //     context: EvaluationContext
-  // ): F[ResolutionDetails[String]]
-  //
+  def resolveStringValue(
+      flagKey: String,
+      defaultValue: String,
+      context: EvaluationContext
+  ): F[ResolutionDetails[String]]
+
   // def resolveIntValue(
   //     flagKey: String,
   //     defaultValue: Int,

--- a/open-feature/sdk/src/main/scala/io/cardell/openfeature/provider/ResolutionDetails.scala
+++ b/open-feature/sdk/src/main/scala/io/cardell/openfeature/provider/ResolutionDetails.scala
@@ -22,10 +22,10 @@ import io.cardell.openfeature.EvaluationReason
 sealed trait FlagMetadataValue
 
 object FlagMetadataValue {
-  case class Boolean(value: Boolean) extends FlagMetadataValue
-  case class String(value: String)   extends FlagMetadataValue
-  case class Int(value: String)      extends FlagMetadataValue
-  case class Double(value: Double)   extends FlagMetadataValue
+  case class BooleanValue(value: Boolean) extends FlagMetadataValue
+  case class StringValue(value: String)   extends FlagMetadataValue
+  case class IntValue(value: String)      extends FlagMetadataValue
+  case class DoubleValue(value: Double)   extends FlagMetadataValue
   // TODO circe unwrapped codecs
 }
 


### PR DESCRIPTION
Using the variant key as the flipt provider is sourced from the Java implementation [here](https://github.com/open-feature/java-sdk-contrib/blob/main/providers/flipt/src/main/java/dev/openfeature/contrib/providers/flipt/FliptProvider.java#L214)