### PR TITLE
Bump otel4s to 0.13.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import build.V
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "0.6"
+ThisBuild / tlBaseVersion := "0.7"
 
 ThisBuild / organization     := "io.cardell"
 ThisBuild / organizationName := "Alex Cardell"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,13 +2,13 @@ package build
 
 object V {
   val cats       = "2.11.0"
-  val catsEffect = "3.6.0"
-  val http4s     = "0.23.26"
-  val circe      = "0.14.7"
-  val otel4s     = "0.12.0"
+  val catsEffect = "3.6.3"
+  val otel4s     = "0.13.2"
   val log4cats   = "2.7.0"
+  val http4s     = "0.23.32"
+  val circe     = "0.14.8"
 
-  val munit           = "1.0.0-RC1"
-  val munitCatsEffect = "2.0.0-M5"
-  val testcontainers  = "0.41.3"
+  val munit           = "1.0.0"
+  val munitCatsEffect = "2.1.0"
+  val testcontainers  = "0.43.6"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,7 +6,7 @@ object V {
   val otel4s     = "0.13.2"
   val log4cats   = "2.7.0"
   val http4s     = "0.23.32"
-  val circe     = "0.14.8"
+  val circe      = "0.14.8"
 
   val munit           = "1.0.0"
   val munitCatsEffect = "2.1.0"


### PR DESCRIPTION
Dependency updates:

* `cats-effect` to 3.6.3
* `otel4s` to 0.13.2
* `http4s` to 0.23.32
*  `circe` to 0.14.8
* `munit` to 1.0.0
* `munit-cats-effect` to 2.1.0
* `testcontainers` to 0.43.6